### PR TITLE
Money dupe patch

### DIFF
--- a/src/main/java/de/codingair/tradesystem/trade/Trade.java
+++ b/src/main/java/de/codingair/tradesystem/trade/Trade.java
@@ -232,6 +232,14 @@ public class Trade {
         Runnable runnable = new Runnable() {
             @Override
             public void run() {
+                // code to avoid some weird money dupe
+                Profile p0 = TradeSystem.getProfile(players[0]);
+                Profile p1 = TradeSystem.getProfile(players[1]);
+                if (p0.getMoney() > money[0] || p1.getMoney() > money[1]) {
+                    cancel(Lang.getPrefix() + Lang.get("Economy_Error"));
+                    return;
+                }
+                
                 TradeSystem.man().getTradeList().remove(Trade.this);
 
                 for(Player player : players) {
@@ -286,9 +294,6 @@ public class Trade {
                 guis[1].clear();
                 guis[0].close();
                 guis[1].close();
-
-                Profile p0 = TradeSystem.getProfile(players[0]);
-                Profile p1 = TradeSystem.getProfile(players[1]);
 
                 double diff = -money[0] + money[1];
                 if(diff < 0) p0.withdraw(-diff);

--- a/src/main/java/de/codingair/tradesystem/trade/Trade.java
+++ b/src/main/java/de/codingair/tradesystem/trade/Trade.java
@@ -235,7 +235,7 @@ public class Trade {
                 // code to avoid some weird money dupe
                 Profile p0 = TradeSystem.getProfile(players[0]);
                 Profile p1 = TradeSystem.getProfile(players[1]);
-                if (p0.getMoney() > money[0] || p1.getMoney() > money[1]) {
+                if (p0.getMoney() < money[0] || p1.getMoney() < money[1]) {
                     cancel(Lang.getPrefix() + Lang.get("Economy_Error"));
                     return;
                 }

--- a/src/main/resources/languages/ENG.yml
+++ b/src/main/resources/languages/ENG.yml
@@ -111,3 +111,4 @@ Offline: Offline
 Your_request_epired: '&7Your trade request to &e%player% &7has &cexpired&7.'
 Request_expired: '&7The trade request from &e%player% &7has &cexpired&7.'
 Fancy_Countdown: ' &7- &e%seconds%s'
+Economy_Error: '&cThe trade was cancelled due to an economy error'

--- a/src/main/resources/languages/ES.yml
+++ b/src/main/resources/languages/ES.yml
@@ -111,3 +111,4 @@ Offline: Offline
 Your_request_epired: '&7Your trade request to &e%player% &7has &cexpired&7.'
 Request_expired: '&7The trade request from &e%player% &7has &cexpired&7.'
 Fancy_Countdown: ' &7- &e%seconds%s'
+Economy_Error: '&cEl intercambio fue cancelado debido a un error en la economía'


### PR DESCRIPTION
Patching simple money dupe

Steps to reproduce the dupe

1. Trade and put all your money
![image](https://user-images.githubusercontent.com/52083283/91671000-aaa48b80-ead7-11ea-8005-4034140a3999.png)
![image](https://user-images.githubusercontent.com/52083283/91671017-c7d95a00-ead7-11ea-9396-2ef9f96697c4.png)
2. Lose money somehow, I.E. eco take (user) (amount)
![image](https://user-images.githubusercontent.com/52083283/91671037-df184780-ead7-11ea-8fbf-4aa23cbd69dd.png)
3.Complete the trade
 The money is not substracted
![image](https://user-images.githubusercontent.com/52083283/91671045-f0f9ea80-ead7-11ea-928a-4905a56f74f7.png)
The money is added to the other account
![image](https://user-images.githubusercontent.com/52083283/91671050-ffe09d00-ead7-11ea-9305-165be693e0d1.png)

The changes just add a verification before completing the trade.
