### PR TITLE
Added TradeItemEvent API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,12 @@
             <artifactId>CodingAPI</artifactId>
             <version>1.7</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.ess3</groupId>

--- a/src/main/java/de/codingair/tradesystem/event/TradeItemEvent.java
+++ b/src/main/java/de/codingair/tradesystem/event/TradeItemEvent.java
@@ -25,9 +25,9 @@ public class TradeItemEvent extends Event {
     /**
      * @param receiver The player who received the item.
      * @param sender The player who gave their item away.
-     * @param item The item.
+     * @param item The item being transferred.
      */
-    public TradeItemEvent(Player receiver, org.bukkit.entity.Player sender, ItemStack item) {
+    public TradeItemEvent(Player receiver, Player sender, ItemStack item) {
         this.receiver = Objects.requireNonNull(receiver, "receiver must not be null!");
         this.sender = Objects.requireNonNull(sender, "sender must not be null!");
         this.item = Objects.requireNonNull(item, "item must not be null!");
@@ -39,14 +39,23 @@ public class TradeItemEvent extends Event {
         return getHandlerList();
     }
 
+    /**
+     * @return The player who received the item.
+     */
     public Player getReceiver() {
         return this.receiver;
     }
 
+    /**
+     * @return The player who gave their item away.
+     */
     public Player getSender() {
         return this.sender;
     }
 
+    /**
+     * @return The item being transferred.
+     */
     public ItemStack getItem() {
         return this.item;
     }

--- a/src/main/java/de/codingair/tradesystem/event/TradeItemEvent.java
+++ b/src/main/java/de/codingair/tradesystem/event/TradeItemEvent.java
@@ -1,0 +1,53 @@
+package de.codingair.tradesystem.event;
+
+import java.util.Objects;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a Player trades an item with another player and the items swap inventories without dropping.
+ * @author SirBlobman
+ */
+public class TradeItemEvent extends Event {
+    private static final HandlerList handlerList = new HandlerList();
+    public static HandlerList getHandlerList() {
+        return handlerList;
+    }
+
+    private final Player receiver, sender;
+    private final ItemStack item;
+
+    /**
+     * @param receiver The player who received the item.
+     * @param sender The player who gave their item away.
+     * @param item The item.
+     */
+    public TradeItemEvent(Player receiver, org.bukkit.entity.Player sender, ItemStack item) {
+        this.receiver = Objects.requireNonNull(receiver, "receiver must not be null!");
+        this.sender = Objects.requireNonNull(sender, "sender must not be null!");
+        this.item = Objects.requireNonNull(item, "item must not be null!");
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
+    }
+
+    public Player getReceiver() {
+        return this.receiver;
+    }
+
+    public Player getSender() {
+        return this.sender;
+    }
+
+    public ItemStack getItem() {
+        return this.item;
+    }
+}

--- a/src/main/java/de/codingair/tradesystem/trade/Trade.java
+++ b/src/main/java/de/codingair/tradesystem/trade/Trade.java
@@ -439,6 +439,7 @@ public class Trade {
     }
 
     private void callTradeEvent(Player receiver, Player sender, ItemStack item) {
+        if(item == null) return;
         TradeItemEvent event = new TradeItemEvent(receiver, sender, item);
         PluginManager pluginManager = Bukkit.getPluginManager();
         pluginManager.callEvent(event);

--- a/src/main/java/de/codingair/tradesystem/trade/Trade.java
+++ b/src/main/java/de/codingair/tradesystem/trade/Trade.java
@@ -1,16 +1,10 @@
 package de.codingair.tradesystem.trade;
 
-import de.codingair.codingapi.API;
-import de.codingair.codingapi.player.gui.anvil.AnvilGUI;
-import de.codingair.codingapi.player.gui.inventory.PlayerInventory;
-import de.codingair.codingapi.tools.items.ItemBuilder;
-import de.codingair.codingapi.tools.items.XMaterial;
-import de.codingair.tradesystem.TradeSystem;
-import de.codingair.tradesystem.trade.layout.Function;
-import de.codingair.tradesystem.trade.layout.Item;
-import de.codingair.tradesystem.trade.layout.utils.Pattern;
-import de.codingair.tradesystem.utils.Lang;
-import de.codingair.tradesystem.utils.Profile;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -19,12 +13,21 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.PluginManager;
 import org.bukkit.scheduler.BukkitRunnable;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
+import de.codingair.codingapi.API;
+import de.codingair.codingapi.player.gui.anvil.AnvilGUI;
+import de.codingair.codingapi.player.gui.inventory.PlayerInventory;
+import de.codingair.codingapi.tools.items.ItemBuilder;
+import de.codingair.codingapi.tools.items.XMaterial;
+import de.codingair.tradesystem.TradeSystem;
+import de.codingair.tradesystem.event.TradeItemEvent;
+import de.codingair.tradesystem.trade.layout.Function;
+import de.codingair.tradesystem.trade.layout.Item;
+import de.codingair.tradesystem.trade.layout.utils.Pattern;
+import de.codingair.tradesystem.utils.Lang;
+import de.codingair.tradesystem.utils.Profile;
 
 import static de.codingair.tradesystem.tradelog.TradeLogService.getTradeLog;
 
@@ -318,6 +321,7 @@ public class Trade {
                     int rest = fit(player1, i0);
 
                     if(rest <= 0) {
+                        callTradeEvent(player1, player2, i0);
                         player1.getInventory().addItem(i0);
                     } else {
                         ItemStack toDrop = i0.clone();
@@ -335,6 +339,7 @@ public class Trade {
                     int rest = fit(player2, i1);
 
                     if(rest <= 0) {
+                        callTradeEvent(player2, player1, i0);
                         player2.getInventory().addItem(i1);
                     } else {
                         ItemStack toDrop = i1.clone();
@@ -431,6 +436,12 @@ public class Trade {
 
             this.countdown.runTaskTimer(TradeSystem.getInstance(), 0, interval);
         }
+    }
+
+    private void callTradeEvent(Player receiver, Player sender, ItemStack item) {
+        TradeItemEvent event = new TradeItemEvent(receiver, sender, item);
+        PluginManager pluginManager = Bukkit.getPluginManager();
+        pluginManager.callEvent(event);
     }
 
     public boolean isFinished() {


### PR DESCRIPTION
Requested by @DeadlykillOfficial

This adds a TradeItemEvent for items that are transferred between inventories. Dropped items and other types of trades are not included in this event.