### PR TITLE
Added indices for tradelog table

### DIFF
--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/utils/database/migrations/mysql/AddIndexTradeLogTableMigration.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/utils/database/migrations/mysql/AddIndexTradeLogTableMigration.java
@@ -1,0 +1,18 @@
+package de.codingair.tradesystem.spigot.utils.database.migrations.mysql;
+
+import de.codingair.tradesystem.spigot.utils.database.migrations.Migration;
+
+public class AddIndexTradeLogTableMigration implements Migration {
+    @Override
+    public String getStatement() {
+        return "ALTER TABLE tradelog "
+                + "ADD INDEX(player1) "
+                + "ADD INDEX(player2) "
+                + "ADD INDEX(timestamp);";
+    }
+
+    @Override
+    public int getVersion() {
+        return 2;
+    }
+}

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/utils/database/migrations/mysql/AddIndexTradeLogTableMigration.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/utils/database/migrations/mysql/AddIndexTradeLogTableMigration.java
@@ -6,8 +6,8 @@ public class AddIndexTradeLogTableMigration implements Migration {
     @Override
     public String getStatement() {
         return "ALTER TABLE tradelog "
-                + "ADD INDEX(player1) "
-                + "ADD INDEX(player2) "
+                + "ADD INDEX(player1), "
+                + "ADD INDEX(player2), "
                 + "ADD INDEX(timestamp);";
     }
 

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/utils/database/migrations/mysql/MysqlMigrations.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/utils/database/migrations/mysql/MysqlMigrations.java
@@ -11,7 +11,9 @@ import java.util.stream.Collectors;
 
 public class MysqlMigrations implements SqlMigrations {
     // Define all migrations in this list.
-    private static final List<Migration> migrations = Arrays.asList(new CreateTradeLogTableMigration());
+    private static final List<Migration> migrations = Arrays.asList(
+            new CreateTradeLogTableMigration(),
+            new AddIndexTradeLogTableMigration());
     private static MysqlMigrations instance;
     private final Connection connection;
 

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/utils/database/migrations/mysql/MysqlMigrations.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/utils/database/migrations/mysql/MysqlMigrations.java
@@ -41,6 +41,8 @@ public class MysqlMigrations implements SqlMigrations {
 
     @Override
     public void runMigrations() throws SQLException {
+        // Disabling auto commit because we want to manually commit
+        connection.setAutoCommit(false);
         int maxVersion = getMaxVersion();
 
         List<Migration> validMigrations = migrations.stream().filter(m -> m.getVersion() > maxVersion)
@@ -59,6 +61,9 @@ public class MysqlMigrations implements SqlMigrations {
                 connection.commit();
             }
         }
+
+        // Reenabling auto commit
+        connection.setAutoCommit(true);
     }
 
     private int getMaxVersion() {

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/utils/database/migrations/sqlite/AddIndexTradeLogTableMigration.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/utils/database/migrations/sqlite/AddIndexTradeLogTableMigration.java
@@ -1,0 +1,16 @@
+package de.codingair.tradesystem.spigot.utils.database.migrations.sqlite;
+
+import de.codingair.tradesystem.spigot.utils.database.migrations.Migration;
+
+public class AddIndexTradeLogTableMigration implements Migration {
+    @Override
+    public String getStatement() {
+        return "CREATE INDEX timestamp_tradelog"
+                + " ON tradelog(timestamp);";
+    }
+
+    @Override
+    public int getVersion() {
+        return 2;
+    }
+}

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/utils/database/migrations/sqlite/SqLiteMigrations.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/utils/database/migrations/sqlite/SqLiteMigrations.java
@@ -5,7 +5,6 @@ import de.codingair.tradesystem.spigot.utils.database.migrations.SqlMigrations;
 
 import java.sql.*;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,7 +13,9 @@ public class SqLiteMigrations implements SqlMigrations {
 
     private static SqLiteMigrations instance;
     // Define all migrations in this list.
-    private static final List<Migration> migrations = Collections.singletonList(new CreateTradeLogTableMigration());
+    private static final List<Migration> migrations = Arrays.asList(
+            new CreateTradeLogTableMigration(),
+            new AddIndexTradeLogTableMigration());
 
     private SqLiteMigrations() {
     }


### PR DESCRIPTION
All 3 columns player1, player2 and timestamp should have an index.

player1/2 need one because they are used in the where statement. timestamp needs one because the result is ordered by it.