### PR TITLE
Added TradeCompleteEvent

### DIFF
--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/api/TradeCompleteEvent.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/api/TradeCompleteEvent.java
@@ -1,15 +1,21 @@
+package de.codingair.tradesystem.spigot.api;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
+@SuppressWarnings("unused")
 public class TradeCompleteEvent extends Event implements Cancellable {
 
     private final Player player1;
     private final Player player2;
-    private final List<ItemStack> player1Items;
-    private final List<ItemStack> player2Items;
+    private List<ItemStack> player1Items;
+    private List<ItemStack> player2Items;
 
     public TradeCompleteEvent(Player player1, Player player2, List<ItemStack> player1Items, List<ItemStack> player2Items) {
         this.player1 = player1;
@@ -42,15 +48,25 @@ public class TradeCompleteEvent extends Event implements Cancellable {
         this.player2Items = player2Items;
     }
 
-    
-    
 
     private static final HandlerList HANDLERS = new HandlerList();
     @Override
-    public HandlerList getHandlers() {
+    public @NotNull HandlerList getHandlers() {
         return HANDLERS;
     }
     public static HandlerList getHandlerList() {
         return HANDLERS;
+    }
+
+    private boolean isCancelled = false;
+
+    @Override
+    public boolean isCancelled() {
+        return isCancelled;
+    }
+    
+    @Override
+    public void setCancelled(boolean b) {
+        isCancelled = b;
     }
 }

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/api/TradeCompleteEvent.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/api/TradeCompleteEvent.java
@@ -1,0 +1,56 @@
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.entity.Player;
+
+public class TradeCompleteEvent extends Event implements Cancellable {
+
+    private final Player player1;
+    private final Player player2;
+    private final List<ItemStack> player1Items;
+    private final List<ItemStack> player2Items;
+
+    public TradeCompleteEvent(Player player1, Player player2, List<ItemStack> player1Items, List<ItemStack> player2Items) {
+        this.player1 = player1;
+        this.player2 = player2;
+        this.player1Items = player1Items;
+        this.player2Items = player2Items;
+    }
+
+    public Player getPlayer1() {
+        return player1;
+    }
+
+    public Player getPlayer2() {
+        return player2;
+    }
+
+    public List<ItemStack> getPlayer1TradeItems() {
+        return player1Items;
+    }
+
+    public void setPlayer1TradeItems(List<ItemStack> player1Items) {
+        this.player1Items = player1Items;
+    }
+
+    public List<ItemStack> getPlayer2TradeItems() {
+        return player2Items;
+    }
+
+    public void setPlayer2TradeItems(List<ItemStack> player2Items) {
+        this.player2Items = player2Items;
+    }
+
+    
+    
+
+    private static final HandlerList HANDLERS = new HandlerList();
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/BukkitTrade.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/BukkitTrade.java
@@ -3,7 +3,6 @@ package de.codingair.tradesystem.spigot.trade;
 import de.codingair.codingapi.API;
 import de.codingair.codingapi.player.gui.anvil.AnvilGUI;
 import de.codingair.codingapi.player.gui.inventory.PlayerInventory;
-import de.codingair.codingapi.player.gui.inventory.v2.exceptions.AlreadyClosedException;
 import de.codingair.codingapi.player.gui.inventory.v2.exceptions.AlreadyOpenedException;
 import de.codingair.codingapi.player.gui.inventory.v2.exceptions.IsWaitingException;
 import de.codingair.codingapi.player.gui.inventory.v2.exceptions.NoPageException;
@@ -275,8 +274,8 @@ public class BukkitTrade extends Trade {
             cancel();
             return;
         }
-        player1Items = tradeCompleteEvent.getPlayer1TradeItems();
-        player2Items = tradeCompleteEvent.getPlayer2TradeItems();
+        List<ItemStack> player1TradeItems = tradeCompleteEvent.getPlayer1TradeItems();
+        List<ItemStack> player2TradeItems = tradeCompleteEvent.getPlayer1TradeItems();
 
         Runnable runnable = () -> {
             if (!tryFinish(player1)) return;
@@ -298,7 +297,7 @@ public class BukkitTrade extends Trade {
             }
 
             boolean[] droppedItems = new boolean[] {false, false};
-            for (ItemStack i0 : player2Items) {
+            for (ItemStack i0 : player2TradeItems) {
                 if (i0 != null && i0.getType() != Material.AIR) {
                     int rest = fit(player1, i0);
 
@@ -317,12 +316,12 @@ public class BukkitTrade extends Trade {
                     getTradeLog().log(player1.getName(), player2.getName(), TradeLogMessages.RECEIVE_ITEM.get(player1.getName(), i0.getAmount() + "x " + i0.getType()));
                 }
             }
-            for (ItemStack i1 : player1Items) {
+            for (ItemStack i1 : player1TradeItems) {
                 if (i1 != null && i1.getType() != Material.AIR) {
                     int rest = fit(player2, i1);
 
                     if (rest <= 0) {
-                        callTradeEvent(player2, player1, i0);
+                        callTradeEvent(player2, player1, i1);
                         player2.getInventory().addItem(i1);
                     } else {
                         ItemStack toDrop = i1.clone();

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/BukkitTrade.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/BukkitTrade.java
@@ -275,8 +275,8 @@ public class BukkitTrade extends Trade {
             return;
         }
         List<ItemStack> player1TradeItems = tradeCompleteEvent.getPlayer1TradeItems();
-        List<ItemStack> player2TradeItems = tradeCompleteEvent.getPlayer1TradeItems();
-
+        List<ItemStack> player2TradeItems = tradeCompleteEvent.getPlayer2TradeItems();
+        
         Runnable runnable = () -> {
             if (!tryFinish(player1)) return;
             if (!tryFinish(player2)) return;

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/BukkitTrade.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/BukkitTrade.java
@@ -269,18 +269,22 @@ public class BukkitTrade extends Trade {
                 player2Items.add(i1);
             }
         }
-        TradeCompleteEvent tradeCompleteEvent = new TradeCompleteEvent(player1, player2, player1Items, player2Items);
-        Bukkit.getPluginManager().callEvent(tradeCompleteEvent);
-        if (tradeCompleteEvent.isCancelled()) {
-            cancel();
-            return;
-        }
-        List<ItemStack> player1TradeItems = tradeCompleteEvent.getPlayer1TradeItems();
-        List<ItemStack> player2TradeItems = tradeCompleteEvent.getPlayer2TradeItems();
-        
+
         Runnable runnable = () -> {
             if (!tryFinish(player1)) return;
             if (!tryFinish(player2)) return;
+
+            TradeCompleteEvent tradeCompleteEvent = new TradeCompleteEvent(player1, player2, player1Items, player2Items);
+            Bukkit.getPluginManager().callEvent(tradeCompleteEvent);
+
+            List<ItemStack> player1TradeItems = tradeCompleteEvent.getPlayer1TradeItems();
+            List<ItemStack> player2TradeItems = tradeCompleteEvent.getPlayer2TradeItems();
+
+            if (tradeCompleteEvent.isCancelled()) {
+                cancel();
+                this.cancel();
+                return;
+            }
 
             pause[0] = true;
             pause[1] = true;

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/BukkitTrade.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/BukkitTrade.java
@@ -270,6 +270,7 @@ public class BukkitTrade extends Trade {
             }
         }
         TradeCompleteEvent tradeCompleteEvent = new TradeCompleteEvent(player1, player2, player1Items, player2Items);
+        Bukkit.getPluginManager().callEvent(tradeCompleteEvent);
         if (tradeCompleteEvent.isCancelled()) {
             cancel();
             return;


### PR DESCRIPTION
I have tested this new event a bit. From what I can tell, everything works. You are able to cancel the event, which will call the Trade cancel() method. You are also able to get and set the items for both players in the trade, editing them will directly edit the items before the trade completes.
Not entirely sure the order of events for the finish method, but the event calls at the desired time and I've found no issues when messing around with the trade and changing some things up.

Note: I added what I need for my own project, editing the BukkitTrade class (didn't get into proxy trades). I did **not** add the other parts of the trade like money, this is **not** a fully flushed-out API with maximum features, it's just a small API I wanted for my own project. I was able to build my own jar and get my project working, up to you if you want to accept this merge into TradeSystem.