### PR TITLE
Separate hover message into accept/deny

### DIFF
--- a/TradeSystem-Bundle/pom.xml
+++ b/TradeSystem-Bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>TradeSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>2.6.3_Hotfix-4</version>
+        <version>2.6.3_Hotfix-5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/TradeSystem-Packets/pom.xml
+++ b/TradeSystem-Packets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>TradeSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>2.6.3_Hotfix-4</version>
+        <version>2.6.3_Hotfix-5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/TradeSystem-Spigot/pom.xml
+++ b/TradeSystem-Spigot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>TradeSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>2.6.3_Hotfix-4</version>
+        <version>2.6.3_Hotfix-5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -132,6 +132,16 @@
             <groupId>net.essentialsx</groupId>
             <artifactId>EssentialsX</artifactId>
             <version>2.19.7</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bstats</groupId>
+                    <artifactId>bstats-bukkit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.md-5</groupId>
+                    <artifactId>bungeecord-chat</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -168,6 +178,12 @@
             <groupId>com.griefdefender</groupId>
             <artifactId>api</artifactId>
             <version>2.1.0-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.kyori</groupId>
+                    <artifactId>event-api</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>provided</scope>
         </dependency>
 

--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/managers/RequestManager.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/trade/managers/RequestManager.java
@@ -85,11 +85,11 @@ public class RequestManager {
 
         TextComponent accept = new TextComponent(Lang.get("Want_To_Trade_Accept", recipient, new Lang.P("player", player)));
         accept.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, commandAccept + " " + player));
-        accept.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new net.md_5.bungee.api.chat.BaseComponent[] {new TextComponent(Lang.get("Want_To_Trade_Hover", recipient))}));
+        accept.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new net.md_5.bungee.api.chat.BaseComponent[] {new TextComponent(Lang.get("Want_To_Trade_Hover_Accept", recipient))}));
 
         TextComponent deny = new TextComponent(Lang.get("Want_To_Trade_Deny", recipient, new Lang.P("player", player)));
         deny.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, commandDeny + " " + player));
-        deny.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new net.md_5.bungee.api.chat.BaseComponent[] {new TextComponent(Lang.get("Want_To_Trade_Hover", recipient))}));
+        deny.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new net.md_5.bungee.api.chat.BaseComponent[] {new TextComponent(Lang.get("Want_To_Trade_Hover_Deny", recipient))}));
 
         message.replace("%accept%", accept);
         message.replace("%deny%", deny);

--- a/TradeSystem-Spigot/src/main/resources/languages/BR.yml
+++ b/TradeSystem-Spigot/src/main/resources/languages/BR.yml
@@ -12,6 +12,8 @@ Want_To_Trade_Bedrock: '&7O Jogador &c%player% &7quer trocar com você. &8[&7/tr
 Want_To_Trade_Accept: '&aAceitar'
 Want_To_Trade_Deny: '&cNegar'
 Want_To_Trade_Hover: '&8» Clique «'
+Want_To_Trade_Hover_Accept: '&8» Clique «'
+Want_To_Trade_Hover_Deny: '&8» Clique «'
 Player_Is_Invited: '&7O Jogador &c%player% &7foi convidado.'
 Command_How_To: '&7Use: /trade <player, accept, deny, toggle>'
 Command_How_To_Accept: '&7Use: /trade accept <Jogador>'

--- a/TradeSystem-Spigot/src/main/resources/languages/CHI.yml
+++ b/TradeSystem-Spigot/src/main/resources/languages/CHI.yml
@@ -12,6 +12,8 @@ Want_To_Trade_Bedrock: '&7玩家&c%player%&7想要和你交易. &8[&7/trade &8<&
 Want_To_Trade_Accept: '&a接受'
 Want_To_Trade_Deny: '&c拒绝'
 Want_To_Trade_Hover: '&8» 点击 «'
+Want_To_Trade_Hover_Accept: '&8» 点击 «'
+Want_To_Trade_Hover_Deny: '&8» 点击 «'
 Player_Is_Invited: '&7已邀请玩家&c%player%&7.'
 Command_How_To: '&7使用: /trade <玩家名, accept, deny, toggle>进行交易'
 Command_How_To_Accept: '&7使用: /trade accept <玩家名>接受交易请求'

--- a/TradeSystem-Spigot/src/main/resources/languages/CS.yml
+++ b/TradeSystem-Spigot/src/main/resources/languages/CS.yml
@@ -12,6 +12,8 @@ Want_To_Trade_Bedrock: '&7Hráč &c%player% &7chce s vámi obchodovat. &8[&7/tra
 Want_To_Trade_Accept: '&aPřijmout'
 Want_To_Trade_Deny: '&cOdmítnout'
 Want_To_Trade_Hover: '&8» Klikni «'
+Want_To_Trade_Hover_Accept: '&8» Klikni «'
+Want_To_Trade_Hover_Deny: '&8» Klikni «'
 Player_Is_Invited: '&7Hráč &c%player% &7 dostal pozvánku k obchodu.'
 Command_How_To: '&7Zadej: /trade <player, accept, deny, toggle>'
 Command_How_To_Accept: '&7Zadej: /trade accept <JménoHráče>'

--- a/TradeSystem-Spigot/src/main/resources/languages/ENG.yml
+++ b/TradeSystem-Spigot/src/main/resources/languages/ENG.yml
@@ -12,6 +12,8 @@ Want_To_Trade_Bedrock: '&7The player &c%player% &7wants to trade with you. &8[&7
 Want_To_Trade_Accept: '&aAccept'
 Want_To_Trade_Deny: '&cDeny'
 Want_To_Trade_Hover: '&8» Click «'
+Want_To_Trade_Hover_Accept: '&8» Click «'
+Want_To_Trade_Hover_Deny: '&8» Click «'
 Player_Is_Invited: '&7The player &c%player% &7was invited.'
 Command_How_To: '&7Use: /trade <player, accept, deny, toggle>'
 Command_How_To_Accept: '&7Use: /trade accept <Player>'

--- a/TradeSystem-Spigot/src/main/resources/languages/ES.yml
+++ b/TradeSystem-Spigot/src/main/resources/languages/ES.yml
@@ -12,6 +12,8 @@ Want_To_Trade_Bedrock: '&7El jugador &2%player% &7quiere intercambiar contigo. &
 Want_To_Trade_Accept: '&aAceptar'
 Want_To_Trade_Deny: '&cRechazar'
 Want_To_Trade_Hover: '&8» Clic «'
+Want_To_Trade_Hover_Accept: '&8» Clic «'
+Want_To_Trade_Hover_Deny: '&8» Clic «'
 Player_Is_Invited: '&7Has enviado una petición de intercambio al jugador &2%player%&7.'
 Command_How_To: '&7Usa: /trade <jugador, accept, deny, toggle>'
 Command_How_To_Accept: '&7Usa: /trade accept <Jugador>'

--- a/TradeSystem-Spigot/src/main/resources/languages/FA.yml
+++ b/TradeSystem-Spigot/src/main/resources/languages/FA.yml
@@ -12,6 +12,8 @@ Want_To_Trade_Bedrock: '&7Bazikon &c%player% &7mikhahad ba shoma tabadol konad. 
 Want_To_Trade_Accept: '&aGhabool'
 Want_To_Trade_Deny: '&cRad'
 Want_To_Trade_Hover: '&8» Click Konid «'
+Want_To_Trade_Hover_Accept: '&8» Click Konid «'
+Want_To_Trade_Hover_Deny: '&8» Click Konid «'
 Player_Is_Invited: '&7Bazikon &c%player% &7daevat shodeh ast.'
 Command_How_To: '&7Estefade konid: /trade <bazikon, ghabool, rad, toggle>'
 Command_How_To_Accept: '&7Estefade konid: /trade accept <Bazikon>'

--- a/TradeSystem-Spigot/src/main/resources/languages/FR.yml
+++ b/TradeSystem-Spigot/src/main/resources/languages/FR.yml
@@ -12,6 +12,8 @@ Want_To_Trade_Bedrock: '&7Le joueur &c%player% &7veut échanger avec vous. &8[&7
 Want_To_Trade_Accept: "&aAccepter"
 Want_To_Trade_Deny: "&cRefuser"
 Want_To_Trade_Hover: "&8» Click «"
+Want_To_Trade_Hover_Accept: "&8» Click «"
+Want_To_Trade_Hover_Deny: "&8» Click «"
 Player_Is_Invited: "&7Le joueur &c%player% &7a été invité."
 Command_How_To: "&7Utilisation: /trade <player, accept, deny, toggle>"
 Command_How_To_Accept: "&7Utilisation: /trade accept <Player>"

--- a/TradeSystem-Spigot/src/main/resources/languages/GER.yml
+++ b/TradeSystem-Spigot/src/main/resources/languages/GER.yml
@@ -12,6 +12,8 @@ Want_To_Trade_Bedrock: '&7Der Spieler &c%player% &7möchte mit dir handeln. &8[&
 Want_To_Trade_Accept: "&aAkzeptieren"
 Want_To_Trade_Deny: "&cAblehnen"
 Want_To_Trade_Hover: "&8» Klick «"
+Want_To_Trade_Hover_Accept: "&8» Klick «"
+Want_To_Trade_Hover_Deny: "&8» Klick «"
 Player_Is_Invited: "&7Der Spieler &c%player% &7wurde eingeladen."
 Command_How_To: "&7Benutze: /trade <Spieler, accept, deny, toggle>"
 Command_How_To_Accept: "&7Benutze: /trade accept <Spieler>"

--- a/TradeSystem-Spigot/src/main/resources/languages/IT.yml
+++ b/TradeSystem-Spigot/src/main/resources/languages/IT.yml
@@ -12,6 +12,8 @@ Want_To_Trade_Bedrock: '&7Il giocatore &c%player% &7vuole fare un scambiare con 
 Want_To_Trade_Accept: '&aAccetta'
 Want_To_Trade_Deny: '&cRifiuta'
 Want_To_Trade_Hover: '&8» Clicca «'
+Want_To_Trade_Hover_Accept: '&8» Clicca «'
+Want_To_Trade_Hover_Deny: '&8» Clicca «'
 Player_Is_Invited: '&7Il giocatore &c%player% &7è statp invitato.'
 Command_How_To: '&7Usa: /trade <giocatore, accept, deny, toggle>'
 Command_How_To_Accept: '&7Usa: /trade accept <giocatore>'

--- a/TradeSystem-Spigot/src/main/resources/languages/JA.yml
+++ b/TradeSystem-Spigot/src/main/resources/languages/JA.yml
@@ -12,6 +12,8 @@ Want_To_Trade_Bedrock: '&7プレイヤー &c%player% &7があなたと取引し�
 Want_To_Trade_Accept: '&a承認'
 Want_To_Trade_Deny: '&c拒否'
 Want_To_Trade_Hover: '&8» クリック «'
+Want_To_Trade_Hover_Accept: '&8» クリック «'
+Want_To_Trade_Hover_Deny: '&8» クリック «'
 Player_Is_Invited: '&7プレイヤー &c%player% &7が招待されました'
 Command_How_To: '&7使用方法: /trade <player, accept, deny, toggle>'
 Command_How_To_Accept: '&7使用方法: /trade accept <Player>'

--- a/TradeSystem-Spigot/src/main/resources/languages/POL.yml
+++ b/TradeSystem-Spigot/src/main/resources/languages/POL.yml
@@ -12,6 +12,8 @@ Want_To_Trade_Bedrock: '&7Gracz &c%player% &7chce się z tobą wymienić. &8[&7/
 Want_To_Trade_Accept: "&aZaakceptuj"
 Want_To_Trade_Deny: "&cOdrzuć"
 Want_To_Trade_Hover: "&8» Kliknij «"
+Want_To_Trade_Hover_Accept: "&8» Kliknij «"
+Want_To_Trade_Hover_Deny: "&8» Kliknij «"
 Player_Is_Invited: "&7Gracz &c%player% &7został zaproszony."
 Command_How_To: "&7Użycie: /trade <Gracz, accept, deny, toggle>"
 Command_How_To_Accept: "&7Użycie: /trade accept <Gracz>"

--- a/TradeSystem-Spigot/src/main/resources/languages/RUS.yml
+++ b/TradeSystem-Spigot/src/main/resources/languages/RUS.yml
@@ -12,6 +12,8 @@ Want_To_Trade_Bedrock: '&7Игрок &c%player% &7хочет провести с
 Want_To_Trade_Accept: '&aПринять'
 Want_To_Trade_Deny: '&cОтклонить'
 Want_To_Trade_Hover: '&8» Нажмите «'
+Want_To_Trade_Hover_Accept: '&8» Нажмите «'
+Want_To_Trade_Hover_Deny: '&8» Нажмите «'
 Player_Is_Invited: '&7Игрок &c%player% &7приглашен.'
 Command_How_To: '&7Использование: /trade <player, accept, deny, toggle>'
 Command_How_To_Accept: '&7Использование: /trade accept <игрока>'

--- a/TradeSystem-Spigot/src/main/resources/languages/TR.yml
+++ b/TradeSystem-Spigot/src/main/resources/languages/TR.yml
@@ -12,6 +12,8 @@ Want_To_Trade_Bedrock: '&c%player% &7adlı oyuncu seninle takas yapmak istiyor. 
 Want_To_Trade_Accept: '&aKabul et'
 Want_To_Trade_Deny: '&cReddet'
 Want_To_Trade_Hover: '&8» Tıkla «'
+Want_To_Trade_Hover_Accept: '&8» Tıkla «'
+Want_To_Trade_Hover_Deny: '&8» Tıkla «'
 Player_Is_Invited: '&c%player% &7adlı oyuncuya istek gönderildi.'
 Command_How_To: '&7Komut: /trade <oyuncu adı, accept, deny, toggle>'
 Command_How_To_Accept: '&7Komut: /trade accept <Player>'

--- a/TradeSystem-Spigot/src/main/resources/languages/UA.yml
+++ b/TradeSystem-Spigot/src/main/resources/languages/UA.yml
@@ -12,6 +12,8 @@ Want_To_Trade_Bedrock: '&7Гравець &c%player% &7хоче провести 
 Want_To_Trade_Accept: '&aПрийняти'
 Want_To_Trade_Deny: '&cВідхилити'
 Want_To_Trade_Hover: '&8» Натисніть «'
+Want_To_Trade_Hover_Accept: '&8» Натисніть «'
+Want_To_Trade_Hover_Deny: '&8» Натисніть «'
 Player_Is_Invited: '&7Гравець &c%player% &7запрошений.'
 Command_How_To: '&7Використання: /trade <player, accept, deny, toggle>'
 Command_How_To_Accept: '&7Використання: /trade accept <гравця>'

--- a/TradeSystem-Spigot/src/main/resources/languages/VI.yml
+++ b/TradeSystem-Spigot/src/main/resources/languages/VI.yml
@@ -12,6 +12,8 @@ Want_To_Trade_Bedrock: '&7Người chơi &c%player% &7muốn giao dịch với b
 Want_To_Trade_Accept: '&aĐồng ý'
 Want_To_Trade_Deny: '&cTừ chối'
 Want_To_Trade_Hover: '&8» Nhấp vào «'
+Want_To_Trade_Hover_Accept: '&8» Nhấp vào «'
+Want_To_Trade_Hover_Deny: '&8» Nhấp vào «'
 Player_Is_Invited: '&7Người chơi &c%player% &7được mời.'
 Command_How_To: '&7Dùng: /trade <player, accept, deny, toggle>'
 Command_How_To_Accept: '&7Dùng: /trade accept <Người chơi>'

--- a/TradeSystem-Spigot/src/main/resources/plugin.yml
+++ b/TradeSystem-Spigot/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: TradeSystem
-author: CodingAir
+author: [ CodingAir, CoolLord22]
 version: "${project.version}"
 description: A beautiful way to trade with other players.
 main: de.codingair.tradesystem.spigot.TradeSystem


### PR DESCRIPTION
Creates new lang placeholders for `Want_To_Trade_Hover_Accept` and `Want_To_Trade_Hover_Deny`

Main reason being, the other components of the messages have both accept/deny variants, hover should as well. Allows users to customize the hover while leaving the generic still the same, e.g. 

```yaml
Want_To_Trade_Hover: '&8» Click «'
Want_To_Trade_Hover_Accept: '&a» Click to Accept «'
Want_To_Trade_Hover_Deny: '&c» Click to Deny «'
```

Wasn't sure how you'd want the lang files for this updated, so I just copied the same existing hover into both fields, feel free to change accordingly.
