### PR TITLE
Add JitPack configuration for OpenJDK 21

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk21

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,6 @@
 jdk:
   - openjdk21
+before_install:
+  - sdk install maven
+install:
+  - mvn install -DskipTests=true


### PR DESCRIPTION
JitPack uses Java 8 by default, which makes builds fail partially due to Spigot API 1.21.4 requiring Java 21. This PR adds a configuration file to make JitPack use OpenJDK 21 for building.

Build status for this PR can be found at https://jitpack.io/com/github/erikzimmermann/TradeSystem/PR595-SNAPSHOT/build.log

