### PR TITLE
Fix exception when running command with no arguments

### DIFF
--- a/TradeSystem-Bundle/pom.xml
+++ b/TradeSystem-Bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>TradeSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>2.6.3_Hotfix-4</version>
+        <version>2.6.3_Hotfix-5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/TradeSystem-Packets/pom.xml
+++ b/TradeSystem-Packets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>TradeSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>2.6.3_Hotfix-4</version>
+        <version>2.6.3_Hotfix-5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/TradeSystem-Spigot/pom.xml
+++ b/TradeSystem-Spigot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>TradeSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>2.6.3_Hotfix-4</version>
+        <version>2.6.3_Hotfix-5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>com.github.CodingAir</groupId>
                 <artifactId>CodingAPI</artifactId>
-                <version>1.97</version>
+                <version>1.98</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
This addresses a recently introduced bug in CodingAPI where running a command with no arguments causes it to throw an exception:

```
[17:11:44] [Server thread/INFO]: BetTD issued server command: /trade
[17:11:44] [Server thread/ERROR]: Command exception: /trade
java.lang.IllegalArgumentException: No such argument 'args' exists on this command
	at com.mojang.brigadier.context.CommandContext.getArgument(CommandContext.java:102) ~[brigadier-1.3.10.jar:?]
	at TradeSystem_v2.6.3_Hotfix-5.jar/de.codingair.tradesystem.lib.codingapi.server.commands.builder.CommandWrapper.run(CommandWrapper.java:90) ~[TradeSystem_v2.6.3_Hotfix-5.jar:?]
	at com.mojang.brigadier.context.ContextChain.runExecutable(ContextChain.java:73) ~[brigadier-1.3.10.jar:?]
	at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:30) ~[purpur-1.21.7.jar:1.21.7-2470-8734844]
[...]
```

This also fixes a recent TradeSystem version bump that was incomplete, resulting in the plugin failing to compile. I haven't been able to test that trading still works, but the plugin starts up properly now, and commands do work correctly.