### PR TITLE
Fix GriefDefender dependency resolution issues

### DIFF
--- a/TradeSystem-Spigot/pom.xml
+++ b/TradeSystem-Spigot/pom.xml
@@ -44,14 +44,10 @@
             <url>https://repo.rosewooddev.io/repository/public/</url>
         </repository>
 
-        <!-- both required for griefdefender for some reason -->
+        <!-- GriefDefender -->
         <repository>
             <id>griefdefender</id>
             <url>https://repo.glaremasters.me/repository/bloodshot</url>
-        </repository>
-        <repository>
-            <id>sonatype_snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
 
         <repository>
@@ -131,7 +127,7 @@
         <dependency>
             <groupId>net.essentialsx</groupId>
             <artifactId>EssentialsX</artifactId>
-            <version>2.19.7</version>
+            <version>2.21.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -169,6 +165,12 @@
             <artifactId>api</artifactId>
             <version>2.1.0-SNAPSHOT</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Both dependencies are required for MMOItems -->


### PR DESCRIPTION
- Add exclusions to GriefDefender API dependency to prevent transitive dependency failures (net.kyori:event-api was unavailable)
- Remove unnecessary sonatype_snapshots repository
- Update EssentialsX from 2.19.7 to 2.21.2 to fix broken transitive deps