### PR TITLE
Fix: custom model data blacklist automatically blocks items without model data

### DIFF
--- a/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/extras/blacklist/BlockedItem.java
+++ b/TradeSystem-Spigot/src/main/java/de/codingair/tradesystem/spigot/extras/blacklist/BlockedItem.java
@@ -167,9 +167,14 @@ public class BlockedItem implements Serializable {
     private boolean missCustomModelData(@NotNull ItemStack item) {
         if (customModelData == null || Version.before(14)) return false;
 
-        if (item.hasItemMeta() && item.getItemMeta() != null) {
-            return customModelData != item.getItemMeta().getCustomModelData();
-        } else return true;
+        if (item.hasItemMeta()) {
+            ItemMeta itemMeta = item.getItemMeta();
+            if (itemMeta != null && itemMeta.hasCustomModelData()) {
+                return customModelData != itemMeta.getCustomModelData();
+            }
+        }
+
+        return true;
     }
 
     @Nullable


### PR DESCRIPTION
This PR fixes an issue where items without custom model data are automatically blacklisted when a custom model data check is added to the blacklisted items list.