### PR TITLE
Bump CodingAPI to 1.101, fixes Paper 26.1.2 startup crash

### DIFF
--- a/TradeSystem-Bundle/pom.xml
+++ b/TradeSystem-Bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>TradeSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>2.6.3_Hotfix-7</version>
+        <version>2.6.3_Hotfix-8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/TradeSystem-Packets/pom.xml
+++ b/TradeSystem-Packets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>TradeSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>2.6.3_Hotfix-7</version>
+        <version>2.6.3_Hotfix-8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/TradeSystem-Spigot/pom.xml
+++ b/TradeSystem-Spigot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>TradeSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>2.6.3_Hotfix-7</version>
+        <version>2.6.3_Hotfix-8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.codingair</groupId>
     <artifactId>TradeSystem</artifactId>
-    <version>2.6.3_Hotfix-7</version>
+    <version>2.6.3_Hotfix-8</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>com.github.CodingAir</groupId>
                 <artifactId>CodingAPI</artifactId>
-                <version>1.100</version>
+                <version>1.101</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
CodingAPI 1.100's version parser misencoded "26.1.2" as 1.02 and routed NMS reflection through the legacy obfuscated path, causing a ClassNotFoundException on plugin enable.